### PR TITLE
Add a Shift+Doubleclick for alternative copy format

### DIFF
--- a/js/plugins/leaflet.clickcopy.js
+++ b/js/plugins/leaflet.clickcopy.js
@@ -16,11 +16,11 @@ import "../leaflet.js";
 })(function (L) {
     L.Map.addInitHook(function () {
         this.on('dblclick', e => {
-            if (e.originalEvent.ctrlKey) {
+            if (e.originalEvent.shiftKey || e.originalEvent.ctrlKey) {
                 let plane = this.getPlane();
                 let x = Math.floor(e.latlng.lng);
                 let y = Math.floor(e.latlng.lat);
-                let copystr = `|x=${x}|y=${y}|plane=${plane}`;
+                let copystr = e.originalEvent.shiftKey ? `|x=${x}|y=${y}|plane=${plane}` : `|${x},${y}`;
                 navigator.clipboard.writeText(copystr).then(() =>
                     this.addMessage(`Copied to clipboard: ${copystr}`), () => console.error("Cannot copy text to clipboard"));
             }

--- a/js/plugins/leaflet.clickcopy.js
+++ b/js/plugins/leaflet.clickcopy.js
@@ -20,7 +20,7 @@ import "../leaflet.js";
                 let plane = this.getPlane();
                 let x = Math.floor(e.latlng.lng);
                 let y = Math.floor(e.latlng.lat);
-                let copystr = e.originalEvent.shiftKey ? `|x=${x}|y=${y}|plane=${plane}` : `|${x},${y}`;
+                let copystr = e.originalEvent.ctrlKey ? `|x=${x}|y=${y}|plane=${plane}` : `|${x},${y}`;
                 navigator.clipboard.writeText(copystr).then(() =>
                     this.addMessage(`Copied to clipboard: ${copystr}`), () => console.error("Cannot copy text to clipboard"));
             }


### PR DESCRIPTION
Although the |x|y|plane format is useful in standalone maps with just a single pin, it's also useful to be able to just quickly copypaste multiple coordinates one by one for use in a polygon map, and you need |x,y|x,y|x,y for that.